### PR TITLE
Filter by array

### DIFF
--- a/lib/elmas/client.rb
+++ b/lib/elmas/client.rb
@@ -5,7 +5,6 @@ module Elmas
     def connection
       Faraday.new do |faraday|
         faraday.adapter Faraday.default_adapter
-        faraday.response :logger
       end
     end
   end

--- a/lib/elmas/client.rb
+++ b/lib/elmas/client.rb
@@ -5,6 +5,7 @@ module Elmas
     def connection
       Faraday.new do |faraday|
         faraday.adapter Faraday.default_adapter
+        faraday.response :logger
       end
     end
   end

--- a/lib/elmas/uri.rb
+++ b/lib/elmas/uri.rb
@@ -19,26 +19,35 @@ module Elmas
       end
 
       def base_filter(attribute)
-        ["$filter", "#{query_attribute(attribute)} eq #{sanitize_value(@attributes[attribute])}"]
+        values = @attributes[attribute]
+        values = [values] unless values.is_a?(Array)
+
+        filters = values.map do |value|
+          "#{query_attribute(attribute)} eq #{sanitize_value(value)}"
+        end
+
+        ["$filter", filters.join(" or ")]
       end
 
       # Sanitize an attribute in symbol format to the ExactOnline style
-      def query_attribute attribute
+      def query_attribute(attribute)
         if attribute == :id
-          query_attribute = attribute.to_s.upcase
+          attribute.to_s.upcase
         else
-          query_attribute = Utils.camelize(attribute)
+          Utils.camelize(attribute)
         end
       end
 
       # Convert a value to something usable in an ExactOnline request
-      def sanitize_value value
+      def sanitize_value(value)
         if value.is_a?(String)
           if value =~ /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
-            value = "guid'#{value}'"
+            "guid'#{value}'"
           else
-            value = "'#{value}'"
+            "'#{value}'"
           end
+        else
+          value
         end
       end
 

--- a/lib/elmas/uri.rb
+++ b/lib/elmas/uri.rb
@@ -18,21 +18,27 @@ module Elmas
         uri
       end
 
-      # ?$filter=ID eq guid'#{id}'
-      def id_filter
-        ["$filter", "ID eq guid'#{id}'"]
+      def base_filter(attribute)
+        ["$filter", "#{query_attribute(attribute)} eq #{sanitize_value(@attributes[attribute])}"]
       end
 
-      def base_filter(attribute)
+      # Sanitize an attribute in symbol format to the ExactOnline style
+      def query_attribute attribute
         if attribute == :id
-          return id_filter
+          query_attribute = attribute.to_s.upcase
         else
-          if @attributes[attribute].is_a?(Fixnum)
-            value = @attributes[attribute]
+          query_attribute = Utils.camelize(attribute)
+        end
+      end
+
+      # Convert a value to something usable in an ExactOnline request
+      def sanitize_value value
+        if value.is_a?(String)
+          if value =~ /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+            value = "guid'#{value}'"
           else
-            value = "'#{@attributes[attribute]}'"
+            value = "'#{value}'"
           end
-          return ["$filter", "#{Utils.camelize(attribute)} eq #{value}"]
         end
       end
 

--- a/spec/resources/bank_entries/bank_entries_api_spec.rb
+++ b/spec/resources/bank_entries/bank_entries_api_spec.rb
@@ -33,11 +33,11 @@ describe Elmas::BankEntry do
     expect(sales_entry.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::BankEntry.new(id: "23", financial_year: "1223") }
+  let(:resource) { resource = Elmas::BankEntry.new(id: "12abcdef-1234-1234-1234-123456abcdef", financial_year: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("financialtransaction/BankEntries(guid'23')?")
+      expect(Elmas).to receive(:get).with("financialtransaction/BankEntries(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -47,14 +47,14 @@ describe Elmas::BankEntry do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("financialtransaction/BankEntries?$filter=FinancialYear+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("financialtransaction/BankEntries?$filter=FinancialYear+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:financial_year, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("financialtransaction/BankEntries?$order_by=FinancialYear&$filter=FinancialYear+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("financialtransaction/BankEntries?$order_by=FinancialYear&$filter=FinancialYear+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:financial_year, :id], order_by: :financial_year)
     end
 

--- a/spec/resources/bank_entry_lines/bank_entry_lines_spec.rb
+++ b/spec/resources/bank_entry_lines/bank_entry_lines_spec.rb
@@ -33,11 +33,11 @@ describe Elmas::BankEntryLine do
     expect(bank_entry_line.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::BankEntryLine.new(id: "23", our_ref: "1223") }
+  let(:resource) { resource = Elmas::BankEntryLine.new(id: "12abcdef-1234-1234-1234-123456abcdef", our_ref: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("financialtransaction/BankEntryLines(guid'23')?")
+      expect(Elmas).to receive(:get).with("financialtransaction/BankEntryLines(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -47,14 +47,14 @@ describe Elmas::BankEntryLine do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("financialtransaction/BankEntryLines?$filter=OurRef+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("financialtransaction/BankEntryLines?$filter=OurRef+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:our_ref, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("financialtransaction/BankEntryLines?$order_by=OurRef&$filter=OurRef+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("financialtransaction/BankEntryLines?$order_by=OurRef&$filter=OurRef+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:our_ref, :id], order_by: :our_ref)
     end
 

--- a/spec/resources/contacts/contacts_api_spec.rb
+++ b/spec/resources/contacts/contacts_api_spec.rb
@@ -24,33 +24,33 @@ describe Elmas::Contact do
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      resource = Elmas::Contact.new(id: "23")
-      expect(Elmas).to receive(:get).with("crm/Contacts(guid'23')?")
+      resource = Elmas::Contact.new(id: "12abcdef-1234-1234-1234-123456abcdef")
+      expect(Elmas).to receive(:get).with("crm/Contacts(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
     it "should apply no filters for find_all" do
-      resource = Elmas::Contact.new(id: "23", name: "Karel")
+      resource = Elmas::Contact.new(id: "12abcdef-1234-1234-1234-123456abcdef", name: "Karel")
       expect(Elmas).to receive(:get).with("crm/Contacts?")
       resource.find_all
     end
 
     it "should apply given filters for find_by" do
-      resource = Elmas::Contact.new(id: "23", name: "Karel")
-      expect(Elmas).to receive(:get).with("crm/Contacts?$filter=Name+eq+'Karel'&$filter=ID+eq+guid'23'")
+      resource = Elmas::Contact.new(id: "12abcdef-1234-1234-1234-123456abcdef", name: "Karel")
+      expect(Elmas).to receive(:get).with("crm/Contacts?$filter=Name+eq+'Karel'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:name, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      resource = Elmas::Contact.new(id: "23", name: "Karel")
-      expect(Elmas).to receive(:get).with("crm/Contacts?$order_by=Name&$filter=Name+eq+'Karel'&$filter=ID+eq+guid'23'")
+      resource = Elmas::Contact.new(id: "12abcdef-1234-1234-1234-123456abcdef", name: "Karel")
+      expect(Elmas).to receive(:get).with("crm/Contacts?$order_by=Name&$filter=Name+eq+'Karel'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:name, :id], order_by: :name)
     end
 
     it "should only apply the order_by" do
-      resource = Elmas::Contact.new(id: "23", name: "Karel")
+      resource = Elmas::Contact.new(id: "12abcdef-1234-1234-1234-123456abcdef", name: "Karel")
       expect(Elmas).to receive(:get).with("crm/Contacts?$order_by=Name")
       resource.find_all(order_by: :name)
     end
@@ -58,19 +58,19 @@ describe Elmas::Contact do
 
   context "Applying select" do
     it "should apply one select" do
-      resource = Elmas::Contact.new(id: "23", name: "Karel")
+      resource = Elmas::Contact.new(id: "12abcdef-1234-1234-1234-123456abcdef", name: "Karel")
       expect(Elmas).to receive(:get).with("crm/Contacts?$select=Name")
       resource.find_all(select: [:name])
     end
 
     it "should apply one select with find_by" do
-      resource = Elmas::Contact.new(id: "23", name: "Karel")
+      resource = Elmas::Contact.new(id: "12abcdef-1234-1234-1234-123456abcdef", name: "Karel")
       expect(Elmas).to receive(:get).with("crm/Contacts?$select=Name")
       resource.find_by(select: [:name])
     end
 
     it "should apply one select" do
-      resource = Elmas::Contact.new(id: "23", name: "Karel")
+      resource = Elmas::Contact.new(id: "12abcdef-1234-1234-1234-123456abcdef", name: "Karel")
       expect(Elmas).to receive(:get).with("crm/Contacts?$select=Name,Age")
       resource.find_all(select: [:name, :age])
     end

--- a/spec/resources/costcenters/costcenters_api_spec.rb
+++ b/spec/resources/costcenters/costcenters_api_spec.rb
@@ -32,11 +32,11 @@ describe Elmas::Costcenter do
     expect(costcenter.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::Costcenter.new(id: "23", code: "1223") }
+  let(:resource) { resource = Elmas::Costcenter.new(id: "12abcdef-1234-1234-1234-123456abcdef", code: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("hrm/Costcenters(guid'23')?")
+      expect(Elmas).to receive(:get).with("hrm/Costcenters(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -46,14 +46,14 @@ describe Elmas::Costcenter do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("hrm/Costcenters?$filter=Code+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("hrm/Costcenters?$filter=Code+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:code, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("hrm/Costcenters?$order_by=Code&$filter=Code+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("hrm/Costcenters?$order_by=Code&$filter=Code+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:code, :id], order_by: :code)
     end
 

--- a/spec/resources/costunits/costunits_api_spec.rb
+++ b/spec/resources/costunits/costunits_api_spec.rb
@@ -32,11 +32,11 @@ describe Elmas::Costunit do
     expect(costunit.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::Costunit.new(id: "23", code: "1223") }
+  let(:resource) { resource = Elmas::Costunit.new(id: "12abcdef-1234-1234-1234-123456abcdef", code: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("hrm/Costunits(guid'23')?")
+      expect(Elmas).to receive(:get).with("hrm/Costunits(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -46,14 +46,14 @@ describe Elmas::Costunit do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("hrm/Costunits?$filter=Code+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("hrm/Costunits?$filter=Code+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:code, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("hrm/Costunits?$order_by=Code&$filter=Code+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("hrm/Costunits?$order_by=Code&$filter=Code+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:code, :id], order_by: :code)
     end
 

--- a/spec/resources/documents/document_attachments_api_spec.rb
+++ b/spec/resources/documents/document_attachments_api_spec.rb
@@ -26,11 +26,11 @@ describe Elmas::DocumentAttachment do
     expect(document.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::DocumentAttachment.new(id: "23", file_name: "1223") }
+  let(:resource) { resource = Elmas::DocumentAttachment.new(id: "12abcdef-1234-1234-1234-123456abcdef", file_name: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("documents/DocumentAttachments(guid'23')?")
+      expect(Elmas).to receive(:get).with("documents/DocumentAttachments(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -40,14 +40,14 @@ describe Elmas::DocumentAttachment do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("documents/DocumentAttachments?$filter=FileName+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("documents/DocumentAttachments?$filter=FileName+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:file_name, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("documents/DocumentAttachments?$order_by=FileName&$filter=FileName+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("documents/DocumentAttachments?$order_by=FileName&$filter=FileName+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:file_name, :id], order_by: :file_name)
     end
 

--- a/spec/resources/documents/documents_spec.rb
+++ b/spec/resources/documents/documents_spec.rb
@@ -26,11 +26,11 @@ describe Elmas::Document do
     expect(document.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::Document.new(id: "23", account: "1223") }
+  let(:resource) { resource = Elmas::Document.new(id: "12abcdef-1234-1234-1234-123456abcdef", account: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("documents/Documents(guid'23')?")
+      expect(Elmas).to receive(:get).with("documents/Documents(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -40,14 +40,14 @@ describe Elmas::Document do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("documents/Documents?$filter=Account+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("documents/Documents?$filter=Account+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:account, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("documents/Documents?$order_by=Account&$filter=Account+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("documents/Documents?$order_by=Account&$filter=Account+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:account, :id], order_by: :account)
     end
 

--- a/spec/resources/gl_accounts/gl_accounts_spec.rb
+++ b/spec/resources/gl_accounts/gl_accounts_spec.rb
@@ -33,11 +33,11 @@ describe Elmas::GLAccount do
     expect(gl_account.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::GLAccount.new(id: "23", code: "1223", description: "IT IS NOT REAL") }
+  let(:resource) { resource = Elmas::GLAccount.new(id: "12abcdef-1234-1234-1234-123456abcdef", code: "1223", description: "IT IS NOT REAL") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("financial/GLAccounts(guid'23')?")
+      expect(Elmas).to receive(:get).with("financial/GLAccounts(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -47,14 +47,14 @@ describe Elmas::GLAccount do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("financial/GLAccounts?$filter=Code+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("financial/GLAccounts?$filter=Code+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:code, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("financial/GLAccounts?$order_by=Code&$filter=Code+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("financial/GLAccounts?$order_by=Code&$filter=Code+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:code, :id], order_by: :code)
     end
 

--- a/spec/resources/invoice_lines/invoice_lines_api_spec.rb
+++ b/spec/resources/invoice_lines/invoice_lines_api_spec.rb
@@ -16,11 +16,11 @@ describe Elmas::SalesInvoiceLine do
     expect(sales_invoice_line.valid?).to eq(true)
   end
 
-  let(:resource) { Elmas::SalesInvoiceLine.new(id: "23", item: "22") }
+  let(:resource) { Elmas::SalesInvoiceLine.new(id: "12abcdef-1234-1234-1234-123456abcdef", item: "22") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoiceLines(guid'23')?")
+      expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoiceLines(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -30,7 +30,7 @@ describe Elmas::SalesInvoiceLine do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoiceLines?$filter=Item+eq+'22'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoiceLines?$filter=Item+eq+'22'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:item, :id])
     end
   end

--- a/spec/resources/invoices/invoices_api_spec.rb
+++ b/spec/resources/invoices/invoices_api_spec.rb
@@ -24,21 +24,21 @@ describe Elmas::SalesInvoice do
   end
 
   context "Applying filters" do
-    resource = Elmas::SalesInvoice.new(id: "23", journal: "22")
+    resource = Elmas::SalesInvoice.new(id: "12abcdef-1234-1234-1234-123456abcdef", journal: "22")
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoices(guid'23')?")
+      expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoices(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
     it "should apply no filters for find_all" do
-      resource = Elmas::SalesInvoice.new(id: "23", journal: "22")
+      resource = Elmas::SalesInvoice.new(id: "12abcdef-1234-1234-1234-123456abcdef", journal: "22")
       expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoices?")
       resource.find_all
     end
 
     it "should apply given filters for find_by" do
-      resource = Elmas::SalesInvoice.new(id: "23", journal: "22")
-      expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoices?$filter=Journal+eq+'22'&$filter=ID+eq+guid'23'")
+      resource = Elmas::SalesInvoice.new(id: "12abcdef-1234-1234-1234-123456abcdef", journal: "22")
+      expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoices?$filter=Journal+eq+'22'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:journal, :id])
     end
   end

--- a/spec/resources/invoices/invoices_api_spec.rb
+++ b/spec/resources/invoices/invoices_api_spec.rb
@@ -41,5 +41,17 @@ describe Elmas::SalesInvoice do
       expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoices?$filter=Journal+eq+'22'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:journal, :id])
     end
+
+    it "should apply given filters for find_by as an array" do
+      resource = Elmas::SalesInvoice.new(id: "12abcdef-1234-1234-1234-123456abcdef", journal: ["22", "24"])
+      expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoices?$filter=Journal+eq+'22'+or+Journal+eq+'24'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
+      resource.find_by(filters: [:journal, :id])
+    end
+
+    it 'should apply a numeric value without quotes' do
+      resource = Elmas::SalesInvoice.new(order_number: 15300007)
+      expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoices?$filter=OrderNumber+eq+15300007")
+      resource.find_by(filters: [:order_number])
+    end
   end
 end

--- a/spec/resources/invoices/layouts_api_spec.rb
+++ b/spec/resources/invoices/layouts_api_spec.rb
@@ -30,8 +30,8 @@ describe Elmas::Layout do
     end
 
     it "should apply given filters for find_by" do
-      resource = Elmas::Layout.new(id: "23", type: "2")
-      expect(Elmas).to receive(:get).with("salesinvoice/Layouts?$filter=Type+eq+'2'&$filter=ID+eq+guid'23'")
+      resource = Elmas::Layout.new(id: "12abcdef-1234-1234-1234-123456abcdef", type: "2")
+      expect(Elmas).to receive(:get).with("salesinvoice/Layouts?$filter=Type+eq+'2'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:type, :id])
     end
   end

--- a/spec/resources/invoices/printed_sales_invoice_spec.rb
+++ b/spec/resources/invoices/printed_sales_invoice_spec.rb
@@ -30,8 +30,8 @@ describe Elmas::PrintedSalesInvoice do
     end
 
     it "should apply given filters for find_by" do
-      resource = Elmas::PrintedSalesInvoice.new(id: "23", type: "2")
-      expect(Elmas).to receive(:get).with("salesinvoice/PrintedSalesInvoices?$filter=Type+eq+'2'&$filter=ID+eq+guid'23'")
+      resource = Elmas::PrintedSalesInvoice.new(id: "12abcdef-1234-1234-1234-123456abcdef", type: "2")
+      expect(Elmas).to receive(:get).with("salesinvoice/PrintedSalesInvoices?$filter=Type+eq+'2'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:type, :id])
     end
   end

--- a/spec/resources/item_groups/item_group_api_spec.rb
+++ b/spec/resources/item_groups/item_group_api_spec.rb
@@ -22,11 +22,11 @@ describe Elmas::ItemGroup do
     expect(item_group.try(:code)).to eq nil
   end
 
-  let(:resource) { resource = Elmas::ItemGroup.new(id: "23", code: "1223") }
+  let(:resource) { resource = Elmas::ItemGroup.new(id: "12abcdef-1234-1234-1234-123456abcdef", code: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("logistics/ItemGroups(guid'23')?")
+      expect(Elmas).to receive(:get).with("logistics/ItemGroups(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -36,14 +36,14 @@ describe Elmas::ItemGroup do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("logistics/ItemGroups?$filter=Code+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("logistics/ItemGroups?$filter=Code+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:code, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("logistics/ItemGroups?$order_by=Code&$filter=Code+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("logistics/ItemGroups?$order_by=Code&$filter=Code+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:code, :id], order_by: :code)
     end
 

--- a/spec/resources/items/item_api_spec.rb
+++ b/spec/resources/items/item_api_spec.rb
@@ -32,11 +32,11 @@ describe Elmas::Item do
     expect(item.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::Item.new(id: "23", code: "1223") }
+  let(:resource) { resource = Elmas::Item.new(id: "12abcdef-1234-1234-1234-123456abcdef", code: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("logistics/Items(guid'23')?")
+      expect(Elmas).to receive(:get).with("logistics/Items(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -46,14 +46,14 @@ describe Elmas::Item do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("logistics/Items?$filter=Code+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("logistics/Items?$filter=Code+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:code, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("logistics/Items?$order_by=Code&$filter=Code+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("logistics/Items?$order_by=Code&$filter=Code+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:code, :id], order_by: :code)
     end
 

--- a/spec/resources/mailboxes/mailboxes_api_spec.rb
+++ b/spec/resources/mailboxes/mailboxes_api_spec.rb
@@ -32,11 +32,11 @@ describe Elmas::Mailbox do
     expect(mailbox.valid?).to eq(true)
   end
 
-  let(:resource) { resource = Elmas::Mailbox.new(id: "23", account: "1223") }
+  let(:resource) { resource = Elmas::Mailbox.new(id: "12abcdef-1234-1234-1234-123456abcdef", account: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("mailbox/Mailboxes(guid'23')?")
+      expect(Elmas).to receive(:get).with("mailbox/Mailboxes(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -46,14 +46,14 @@ describe Elmas::Mailbox do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("mailbox/Mailboxes?$filter=Account+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("mailbox/Mailboxes?$filter=Account+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:account, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("mailbox/Mailboxes?$order_by=Account&$filter=Account+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("mailbox/Mailboxes?$order_by=Account&$filter=Account+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:account, :id], order_by: :account)
     end
 

--- a/spec/resources/projects/projects_api_spec.rb
+++ b/spec/resources/projects/projects_api_spec.rb
@@ -24,33 +24,33 @@ describe Elmas::Project do
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      resource = Elmas::Project.new(id: "23")
-      expect(Elmas).to receive(:get).with("project/Projects(guid'23')?")
+      resource = Elmas::Project.new(id: "12abcdef-1234-1234-1234-123456abcdef")
+      expect(Elmas).to receive(:get).with("project/Projects(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
     it "should apply no filters for find_all" do
-      resource = Elmas::Project.new(id: "23", code: "P001")
+      resource = Elmas::Project.new(id: "12abcdef-1234-1234-1234-123456abcdef", code: "P001")
       expect(Elmas).to receive(:get).with("project/Projects?")
       resource.find_all
     end
 
     it "should apply given filters for find_by" do
-      resource = Elmas::Project.new(id: "23", code: "P001")
-      expect(Elmas).to receive(:get).with("project/Projects?$filter=Code+eq+'P001'&$filter=ID+eq+guid'23'")
+      resource = Elmas::Project.new(id: "12abcdef-1234-1234-1234-123456abcdef", code: "P001")
+      expect(Elmas).to receive(:get).with("project/Projects?$filter=Code+eq+'P001'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:code, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      resource = Elmas::Project.new(id: "23", code: "P001")
-      expect(Elmas).to receive(:get).with("project/Projects?$order_by=Code&$filter=Code+eq+'P001'&$filter=ID+eq+guid'23'")
+      resource = Elmas::Project.new(id: "12abcdef-1234-1234-1234-123456abcdef", code: "P001")
+      expect(Elmas).to receive(:get).with("project/Projects?$order_by=Code&$filter=Code+eq+'P001'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:code, :id], order_by: :code)
     end
 
     it "should only apply the order_by" do
-      resource = Elmas::Project.new(id: "23", code: "P001")
+      resource = Elmas::Project.new(id: "12abcdef-1234-1234-1234-123456abcdef", code: "P001")
       expect(Elmas).to receive(:get).with("project/Projects?$order_by=Code")
       resource.find_all(order_by: :code)
     end
@@ -58,19 +58,19 @@ describe Elmas::Project do
 
   context "Applying select" do
     it "should apply one select" do
-      resource = Elmas::Project.new(id: "23", code: "P001")
+      resource = Elmas::Project.new(id: "12abcdef-1234-1234-1234-123456abcdef", code: "P001")
       expect(Elmas).to receive(:get).with("project/Projects?$select=Code")
       resource.find_all(select: [:code])
     end
 
     it "should apply one select with find_by" do
-      resource = Elmas::Project.new(id: "23", code: "P001")
+      resource = Elmas::Project.new(id: "12abcdef-1234-1234-1234-123456abcdef", code: "P001")
       expect(Elmas).to receive(:get).with("project/Projects?$select=Code")
       resource.find_by(select: [:code])
     end
 
     it "should apply one select" do
-      resource = Elmas::Project.new(id: "23", code: "P001")
+      resource = Elmas::Project.new(id: "12abcdef-1234-1234-1234-123456abcdef", code: "P001")
       expect(Elmas).to receive(:get).with("project/Projects?$select=Code,Description")
       resource.find_all(select: [:code, :description])
     end

--- a/spec/resources/purchase_entries/purchase_entries_api_spec.rb
+++ b/spec/resources/purchase_entries/purchase_entries_api_spec.rb
@@ -33,11 +33,11 @@ describe Elmas::PurchaseEntry do
     expect(purchase_entry.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::PurchaseEntry.new(id: "23", batch_number: "1223") }
+  let(:resource) { resource = Elmas::PurchaseEntry.new(id: "12abcdef-1234-1234-1234-123456abcdef", batch_number: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("purchaseentry/PurchaseEntries(guid'23')?")
+      expect(Elmas).to receive(:get).with("purchaseentry/PurchaseEntries(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -47,14 +47,14 @@ describe Elmas::PurchaseEntry do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("purchaseentry/PurchaseEntries?$filter=BatchNumber+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("purchaseentry/PurchaseEntries?$filter=BatchNumber+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:batch_number, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("purchaseentry/PurchaseEntries?$order_by=BatchNumber&$filter=BatchNumber+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("purchaseentry/PurchaseEntries?$order_by=BatchNumber&$filter=BatchNumber+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:batch_number, :id], order_by: :batch_number)
     end
 

--- a/spec/resources/sales_entries/sales_entries_api_spec.rb
+++ b/spec/resources/sales_entries/sales_entries_api_spec.rb
@@ -33,11 +33,11 @@ describe Elmas::SalesEntry do
     expect(sales_entry.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::SalesEntry.new(id: "23", batch_number: "1223") }
+  let(:resource) { resource = Elmas::SalesEntry.new(id: "12abcdef-1234-1234-1234-123456abcdef", batch_number: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("salesentry/SalesEntries(guid'23')?")
+      expect(Elmas).to receive(:get).with("salesentry/SalesEntries(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -47,14 +47,14 @@ describe Elmas::SalesEntry do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("salesentry/SalesEntries?$filter=BatchNumber+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("salesentry/SalesEntries?$filter=BatchNumber+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:batch_number, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("salesentry/SalesEntries?$order_by=BatchNumber&$filter=BatchNumber+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("salesentry/SalesEntries?$order_by=BatchNumber&$filter=BatchNumber+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:batch_number, :id], order_by: :batch_number)
     end
 

--- a/spec/resources/sales_entry_lines/sales_entry_lines_spec.rb
+++ b/spec/resources/sales_entry_lines/sales_entry_lines_spec.rb
@@ -33,11 +33,11 @@ describe Elmas::SalesEntryLine do
     expect(sales_entry_line.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::SalesEntryLine.new(id: "23", serial_number: "1223") }
+  let(:resource) { resource = Elmas::SalesEntryLine.new(id: "12abcdef-1234-1234-1234-123456abcdef", serial_number: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("salesentry/SalesEntryLines(guid'23')?")
+      expect(Elmas).to receive(:get).with("salesentry/SalesEntryLines(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -47,14 +47,14 @@ describe Elmas::SalesEntryLine do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("salesentry/SalesEntryLines?$filter=SerialNumber+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("salesentry/SalesEntryLines?$filter=SerialNumber+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:serial_number, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("salesentry/SalesEntryLines?$order_by=SerialNumber&$filter=SerialNumber+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("salesentry/SalesEntryLines?$order_by=SerialNumber&$filter=SerialNumber+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:serial_number, :id], order_by: :serial_number)
     end
 

--- a/spec/resources/sales_order_lines/sales_order_lines_api_spec.rb
+++ b/spec/resources/sales_order_lines/sales_order_lines_api_spec.rb
@@ -33,11 +33,11 @@ describe Elmas::SalesOrderLine do
     expect(sales_order_line.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::SalesOrderLine.new(id: "23", order_number: "1223") }
+  let(:resource) { resource = Elmas::SalesOrderLine.new(id: "12abcdef-1234-1234-1234-123456abcdef", order_number: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("salesorder/SalesOrderLines(guid'23')?")
+      expect(Elmas).to receive(:get).with("salesorder/SalesOrderLines(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -47,14 +47,14 @@ describe Elmas::SalesOrderLine do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("salesorder/SalesOrderLines?$filter=OrderNumber+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("salesorder/SalesOrderLines?$filter=OrderNumber+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:order_number, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("salesorder/SalesOrderLines?$order_by=OrderNumber&$filter=OrderNumber+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("salesorder/SalesOrderLines?$order_by=OrderNumber&$filter=OrderNumber+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:order_number, :id], order_by: :order_number)
     end
 

--- a/spec/resources/sales_orders/sales_orders_api_spec.rb
+++ b/spec/resources/sales_orders/sales_orders_api_spec.rb
@@ -33,11 +33,11 @@ describe Elmas::SalesOrder do
     expect(sales_order.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::SalesOrder.new(id: "23", order_number: "1223") }
+  let(:resource) { resource = Elmas::SalesOrder.new(id: "12abcdef-1234-1234-1234-123456abcdef", order_number: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("salesorder/SalesOrders(guid'23')?")
+      expect(Elmas).to receive(:get).with("salesorder/SalesOrders(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -47,14 +47,14 @@ describe Elmas::SalesOrder do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("salesorder/SalesOrders?$filter=OrderNumber+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("salesorder/SalesOrders?$filter=OrderNumber+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:order_number, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("salesorder/SalesOrders?$order_by=OrderNumber&$filter=OrderNumber+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("salesorder/SalesOrders?$order_by=OrderNumber&$filter=OrderNumber+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:order_number, :id], order_by: :order_number)
     end
 

--- a/spec/resources/time_transactions/time_transactions_api_spec.rb
+++ b/spec/resources/time_transactions/time_transactions_api_spec.rb
@@ -24,33 +24,33 @@ describe Elmas::TimeTransaction do
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      resource = Elmas::TimeTransaction.new(id: "23")
-      expect(Elmas).to receive(:get).with("project/TimeTransactions(guid'23')?")
+      resource = Elmas::TimeTransaction.new(id: "12abcdef-1234-1234-1234-123456abcdef")
+      expect(Elmas).to receive(:get).with("project/TimeTransactions(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
     it "should apply no filters for find_all" do
-      resource = Elmas::TimeTransaction.new(id: "23", item: "eb73942a-53c0-4ee9-bbb2-6d985814a1b1")
+      resource = Elmas::TimeTransaction.new(id: "12abcdef-1234-1234-1234-123456abcdef", item: "eb73942a-53c0-4ee9-bbb2-6d985814a1b1")
       expect(Elmas).to receive(:get).with("project/TimeTransactions?")
       resource.find_all
     end
 
     it "should apply given filters for find_by" do
-      resource = Elmas::TimeTransaction.new(id: "23", item: "eb73942a-53c0-4ee9-bbb2-6d985814a1b1")
-      expect(Elmas).to receive(:get).with("project/TimeTransactions?$filter=Item+eq+'eb73942a-53c0-4ee9-bbb2-6d985814a1b1'&$filter=ID+eq+guid'23'")
+      resource = Elmas::TimeTransaction.new(id: "12abcdef-1234-1234-1234-123456abcdef", item: "eb73942a-53c0-4ee9-bbb2-6d985814a1b1")
+      expect(Elmas).to receive(:get).with("project/TimeTransactions?$filter=Item+eq+guid'eb73942a-53c0-4ee9-bbb2-6d985814a1b1'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:item, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      resource = Elmas::TimeTransaction.new(id: "23", item: "eb73942a-53c0-4ee9-bbb2-6d985814a1b1")
-      expect(Elmas).to receive(:get).with("project/TimeTransactions?$order_by=Item&$filter=Item+eq+'eb73942a-53c0-4ee9-bbb2-6d985814a1b1'&$filter=ID+eq+guid'23'")
+      resource = Elmas::TimeTransaction.new(id: "12abcdef-1234-1234-1234-123456abcdef", item: "eb73942a-53c0-4ee9-bbb2-6d985814a1b1")
+      expect(Elmas).to receive(:get).with("project/TimeTransactions?$order_by=Item&$filter=Item+eq+guid'eb73942a-53c0-4ee9-bbb2-6d985814a1b1'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:item, :id], order_by: :item)
     end
 
     it "should only apply the order_by" do
-      resource = Elmas::TimeTransaction.new(id: "23", item: "eb73942a-53c0-4ee9-bbb2-6d985814a1b1")
+      resource = Elmas::TimeTransaction.new(id: "12abcdef-1234-1234-1234-123456abcdef", item: "eb73942a-53c0-4ee9-bbb2-6d985814a1b1")
       expect(Elmas).to receive(:get).with("project/TimeTransactions?$order_by=Item")
       resource.find_all(order_by: :item)
     end
@@ -58,19 +58,19 @@ describe Elmas::TimeTransaction do
 
   context "Applying select" do
     it "should apply one select" do
-      resource = Elmas::TimeTransaction.new(id: "23", item: "eb73942a-53c0-4ee9-bbb2-6d985814a1b1")
+      resource = Elmas::TimeTransaction.new(id: "12abcdef-1234-1234-1234-123456abcdef", item: "eb73942a-53c0-4ee9-bbb2-6d985814a1b1")
       expect(Elmas).to receive(:get).with("project/TimeTransactions?$select=Item")
       resource.find_all(select: [:item])
     end
 
     it "should apply one select with find_by" do
-      resource = Elmas::TimeTransaction.new(id: "23", item: "eb73942a-53c0-4ee9-bbb2-6d985814a1b1")
+      resource = Elmas::TimeTransaction.new(id: "12abcdef-1234-1234-1234-123456abcdef", item: "eb73942a-53c0-4ee9-bbb2-6d985814a1b1")
       expect(Elmas).to receive(:get).with("project/TimeTransactions?$select=Item")
       resource.find_by(select: [:item])
     end
 
     it "should apply one select" do
-      resource = Elmas::TimeTransaction.new(id: "23", item: "eb73942a-53c0-4ee9-bbb2-6d985814a1b1")
+      resource = Elmas::TimeTransaction.new(id: "12abcdef-1234-1234-1234-123456abcdef", item: "eb73942a-53c0-4ee9-bbb2-6d985814a1b1")
       expect(Elmas).to receive(:get).with("project/TimeTransactions?$select=Item,Notes")
       resource.find_all(select: [:item, :notes])
     end

--- a/spec/resources/transaction_lines/transaction_lines_spec.rb
+++ b/spec/resources/transaction_lines/transaction_lines_spec.rb
@@ -22,11 +22,11 @@ describe Elmas::TransactionLine do
     expect(transaction_line.try(:amount_FC)).to eq nil
   end
 
-  let(:resource) { resource = Elmas::TransactionLine.new(id: "23", asset_code: "1223") }
+  let(:resource) { resource = Elmas::TransactionLine.new(id: "12abcdef-1234-1234-1234-123456abcdef", asset_code: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("financialtransaction/TransactionLines(guid'23')?")
+      expect(Elmas).to receive(:get).with("financialtransaction/TransactionLines(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -36,14 +36,14 @@ describe Elmas::TransactionLine do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("financialtransaction/TransactionLines?$filter=AssetCode+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("financialtransaction/TransactionLines?$filter=AssetCode+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:asset_code, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("financialtransaction/TransactionLines?$order_by=AssetCode&$filter=AssetCode+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("financialtransaction/TransactionLines?$order_by=AssetCode&$filter=AssetCode+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:asset_code, :id], order_by: :asset_code)
     end
 

--- a/spec/resources/transactions/transactions_spec.rb
+++ b/spec/resources/transactions/transactions_spec.rb
@@ -22,11 +22,11 @@ describe Elmas::Transaction do
     expect(transaction.try(:amount_FC)).to eq nil
   end
 
-  let(:resource) { resource = Elmas::Transaction.new(id: "23", description: "1223") }
+  let(:resource) { resource = Elmas::Transaction.new(id: "12abcdef-1234-1234-1234-123456abcdef", description: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("financialtransaction/Transactions(guid'23')?")
+      expect(Elmas).to receive(:get).with("financialtransaction/Transactions(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -36,14 +36,14 @@ describe Elmas::Transaction do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("financialtransaction/Transactions?$filter=Description+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("financialtransaction/Transactions?$filter=Description+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:description, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("financialtransaction/Transactions?$order_by=Description&$filter=Description+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("financialtransaction/Transactions?$order_by=Description&$filter=Description+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:description, :id], order_by: :description)
     end
 

--- a/spec/resources/vat_codes/vat_codes_spec.rb
+++ b/spec/resources/vat_codes/vat_codes_spec.rb
@@ -32,11 +32,11 @@ describe Elmas::VatCode do
     expect(vat_code.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::VatCode.new(id: "23", code: "1223") }
+  let(:resource) { resource = Elmas::VatCode.new(id: "12abcdef-1234-1234-1234-123456abcdef", code: "1223") }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
-      expect(Elmas).to receive(:get).with("vat/VATCodes(guid'23')?")
+      expect(Elmas).to receive(:get).with("vat/VATCodes(guid'12abcdef-1234-1234-1234-123456abcdef')?")
       resource.find
     end
 
@@ -46,14 +46,14 @@ describe Elmas::VatCode do
     end
 
     it "should apply given filters for find_by" do
-      expect(Elmas).to receive(:get).with("vat/VATCodes?$filter=Code+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("vat/VATCodes?$filter=Code+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:code, :id])
     end
   end
 
   context "Applying order" do
     it "should apply the order_by and filters" do
-      expect(Elmas).to receive(:get).with("vat/VATCodes?$order_by=Code&$filter=Code+eq+'1223'&$filter=ID+eq+guid'23'")
+      expect(Elmas).to receive(:get).with("vat/VATCodes?$order_by=Code&$filter=Code+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:code, :id], order_by: :code)
     end
 


### PR DESCRIPTION
Allow filtering by multiple ids (or other attributes), e.g.

    SalesInvoice.new(id: [1,2]).find_by(filter: [:id])

would find invoices with ids 1 and 2