### PR TITLE
Allow filtering with 'greater_than' and 'less_than'

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,10 @@ the `next_page` method.
 accounts.next_page
 ```
 
-### Filter results
+### Filter and sort results
 
 Filtering result sets can be done by adding attributes to the initializer and then
 using `find_by`. Filters accept a single value or an array of values.
-
-So far only 'eq' has been implemented, so only direct matches will be returned.
 
 ```ruby
 # Find the account with code 123
@@ -120,6 +118,13 @@ accounts = Elmas::Account.new(code: '123').find_by(filter: [:code])
 
 # Find the accounts with code 123 and 345
 accounts = Elmas::Account.new(code: ['123', '345']).find_by(filter: [:code])
+```
+
+You can also match on values "greater than" or "less than" by specifying `gt` or `lt`:
+
+```ruby
+# Find all AgingReceivables with an amount greater than 0 in the third age range
+Elmas::AgingReceivablesList.new(age_group3_amount: { gt: 0 }).find_by(filters: [:age_group3_amount])
 ```
 
 Results can be sorted in the same way

--- a/lib/elmas/uri.rb
+++ b/lib/elmas/uri.rb
@@ -23,8 +23,14 @@ module Elmas
         values = [values] unless values.is_a?(Array)
 
         filters = values.map do |value|
-          "#{query_attribute(attribute)} eq #{sanitize_value(value)}"
-        end
+          if value.is_a?(Hash)
+            value.map do |key, val|
+              "#{query_attribute(attribute)} #{key} #{sanitize_value(val)}"
+            end
+          else
+            "#{query_attribute(attribute)} eq #{sanitize_value(value)}"
+          end
+        end.flatten
 
         ["$filter", filters.join(" or ")]
       end

--- a/spec/resources/invoice_lines/invoice_lines_api_spec.rb
+++ b/spec/resources/invoice_lines/invoice_lines_api_spec.rb
@@ -33,5 +33,17 @@ describe Elmas::SalesInvoiceLine do
       expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoiceLines?$filter=Item+eq+'22'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:item, :id])
     end
+
+    it "should apply greater-than filters" do
+      resource = Elmas::SalesInvoiceLine.new(net_price: { gt: 5 })
+      expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoiceLines?$filter=NetPrice+gt+5")
+      resource.find_by(filters: [:net_price])
+    end
+
+    it "should apply less-than filters" do
+      resource = Elmas::SalesInvoiceLine.new(net_price: { lt: 5 })
+      expect(Elmas).to receive(:get).with("salesinvoice/SalesInvoiceLines?$filter=NetPrice+lt+5")
+      resource.find_by(filters: [:net_price])
+    end
   end
 end


### PR DESCRIPTION
Until now we could only filter on `eq` but I need to filter on `gt` and `lt`