### PR TITLE
Fix sanitizing of various types of dates/times

### DIFF
--- a/lib/elmas/sanitizer.rb
+++ b/lib/elmas/sanitizer.rb
@@ -21,7 +21,7 @@ module Elmas
           return value.id # Turn relation into ID
         elsif value.is_a?(Array)
           return sanitize_has_many(value)
-        elsif value.is_a?(DateTime)
+        elsif value.is_a?(Time) || value.is_a?(Date) || value.is_a?(DateTime)
           return sanitize_date_time(value)
         elsif value.is_a?(String) && value.match(/(Date\()/)
           number = value.scan(/\d+/).first.to_i / 1000.0


### PR DESCRIPTION
Currently only `DateTime`s are properly sanitized. This excludes `Date`s and things like `ActiveSupport::TimeWithZone`