### PR TITLE
on resource requests, auto refresh access tokens

### DIFF
--- a/lib/elmas/resource.rb
+++ b/lib/elmas/resource.rb
@@ -97,10 +97,9 @@ module Elmas
     private
 
     def ensure_fresh_authorization
-      unless Elmas.authorized?
-        Elmas.configure do |config|
-          config.access_token = Elmas.authorize(ENV['EXACT_USER_NAME'], ENV['EXACT_PASSWORD']).access_token
-        end
+      return if Elmas.authorized?
+      Elmas.configure do |config|
+        config.access_token = Elmas.authorize(ENV["EXACT_USER_NAME"], ENV["EXACT_PASSWORD"]).access_token
       end
     end
 

--- a/lib/elmas/resource.rb
+++ b/lib/elmas/resource.rb
@@ -24,7 +24,9 @@ module Elmas
     def find_all(options = {})
       @order_by = options[:order_by]
       @select = options[:select]
-      response = get(uri([:order, :select]))
+      @expand = options[:expand]
+      @top = options[:top]
+      response = get(uri([:order, :select, :expand, :top]))
       response.results if response
     end
 
@@ -33,7 +35,9 @@ module Elmas
       @filters = options[:filters]
       @order_by = options[:order_by]
       @select = options[:select]
-      response = get(uri([:order, :select, :filters]))
+      @expand = options[:expand]
+      @top = options[:top]
+      response = get(uri([:order, :select, :filters, :expand, :top]))
       response.results if response
     end
 
@@ -45,6 +49,7 @@ module Elmas
 
     # Normally use the url method (which applies the filters) but sometimes you only want to use the base path or other paths
     def get(uri = self.uri)
+      ensure_fresh_authorization
       @response = Elmas.get(URI.unescape(uri.to_s))
     end
 
@@ -61,6 +66,7 @@ module Elmas
     end
 
     def save
+      ensure_fresh_authorization
       attributes_to_submit = sanitize
       if valid?
         return @response = Elmas.post(base_path, params: attributes_to_submit) unless id?
@@ -72,6 +78,7 @@ module Elmas
     end
 
     def delete
+      ensure_fresh_authorization
       return nil unless id?
       Elmas.delete(basic_identifier_uri)
     end
@@ -88,6 +95,14 @@ module Elmas
     end
 
     private
+
+    def ensure_fresh_authorization
+      unless Elmas.authorized?
+        Elmas.configure do |config|
+          config.access_token = Elmas.authorize(ENV['EXACT_USER_NAME'], ENV['EXACT_PASSWORD']).access_token
+        end
+      end
+    end
 
     def set_attribute(attribute, value)
       @attributes[attribute.to_sym] = value if valid_attribute?(attribute)

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -10,6 +10,9 @@ describe Elmas::Request do
   let(:url_with_division) { "#{base_url}/#{division}"}
 
   before :each do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
     Elmas.configure do |config|
       config.base_url = base_url
       config.endpoint = endpoint

--- a/spec/resources/accounts/accounts_api_spec.rb
+++ b/spec/resources/accounts/accounts_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::Account do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     account = Elmas::Account.new
     expect(account).to be_a(Elmas::Account)

--- a/spec/resources/bank_entries/bank_entries_api_spec.rb
+++ b/spec/resources/bank_entries/bank_entries_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::BankEntry do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     sales_entry = Elmas::BankEntry.new
     expect(sales_entry).to be_a(Elmas::BankEntry)

--- a/spec/resources/bank_entry_lines/bank_entry_lines_spec.rb
+++ b/spec/resources/bank_entry_lines/bank_entry_lines_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::BankEntryLine do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     bank_entry_line = Elmas::BankEntryLine.new
     expect(bank_entry_line).to be_a(Elmas::BankEntryLine)

--- a/spec/resources/contacts/contacts_api_spec.rb
+++ b/spec/resources/contacts/contacts_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::Contact do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     contact = Elmas::Contact.new
     expect(contact).to be_a(Elmas::Contact)

--- a/spec/resources/costcenters/costcenters_api_spec.rb
+++ b/spec/resources/costcenters/costcenters_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::Costcenter do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     costcenter = Elmas::Costcenter.new
     expect(costcenter).to be_a(Elmas::Costcenter)

--- a/spec/resources/costunits/costunits_api_spec.rb
+++ b/spec/resources/costunits/costunits_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::Costunit do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     costunit = Elmas::Costunit.new
     expect(costunit).to be_a(Elmas::Costunit)

--- a/spec/resources/documents/document_attachments_api_spec.rb
+++ b/spec/resources/documents/document_attachments_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::DocumentAttachment do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     document = Elmas::DocumentAttachment.new
     expect(document).to be_a(Elmas::DocumentAttachment)

--- a/spec/resources/documents/documents_spec.rb
+++ b/spec/resources/documents/documents_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::Document do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     document = Elmas::Document.new
     expect(document).to be_a(Elmas::Document)

--- a/spec/resources/financial/aging_receivables_list_spec.rb
+++ b/spec/resources/financial/aging_receivables_list_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::AgingReceivablesList do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     sales_invoice = Elmas::AgingReceivablesList.new
     expect(sales_invoice).to be_a(Elmas::AgingReceivablesList)

--- a/spec/resources/general_journal_entries/general_journal_entries.api_spec.rb
+++ b/spec/resources/general_journal_entries/general_journal_entries.api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::GeneralJournalEntry do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     general_journal_entry = Elmas::GeneralJournalEntry.new
     expect(general_journal_entry).to be_a(Elmas::GeneralJournalEntry)

--- a/spec/resources/general_journal_entry_lines/general_journal_entry_lines.rb
+++ b/spec/resources/general_journal_entry_lines/general_journal_entry_lines.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::GeneralJournalEntryLine do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     general_journal_entry_line = Elmas::GeneralJournalEntryLine.new
     expect(general_journal_entry_line).to be_a(Elmas::GeneralJournalEntryLine)

--- a/spec/resources/gl_accounts/gl_accounts_spec.rb
+++ b/spec/resources/gl_accounts/gl_accounts_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::GLAccount do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     gl_account = Elmas::GLAccount.new
     expect(gl_account).to be_a(Elmas::GLAccount)

--- a/spec/resources/invoice_lines/invoice_lines_api_spec.rb
+++ b/spec/resources/invoice_lines/invoice_lines_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::SalesInvoiceLine do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     sales_invoice_line = Elmas::SalesInvoiceLine.new
     expect(sales_invoice_line).to be_a(Elmas::SalesInvoiceLine)

--- a/spec/resources/invoices/invoices_api_spec.rb
+++ b/spec/resources/invoices/invoices_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::SalesInvoice do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     sales_invoice = Elmas::SalesInvoice.new
     expect(sales_invoice).to be_a(Elmas::SalesInvoice)

--- a/spec/resources/invoices/layouts_api_spec.rb
+++ b/spec/resources/invoices/layouts_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::Layout do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     sales_invoice = Elmas::Layout.new
     expect(sales_invoice).to be_a(Elmas::Layout)

--- a/spec/resources/invoices/printed_sales_invoice_spec.rb
+++ b/spec/resources/invoices/printed_sales_invoice_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::PrintedSalesInvoice do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     sales_invoice = Elmas::PrintedSalesInvoice.new
     expect(sales_invoice).to be_a(Elmas::PrintedSalesInvoice)

--- a/spec/resources/item_groups/item_group_api_spec.rb
+++ b/spec/resources/item_groups/item_group_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::ItemGroup do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     item_group = Elmas::ItemGroup.new
     expect(item_group).to be_a(Elmas::ItemGroup)

--- a/spec/resources/items/item_api_spec.rb
+++ b/spec/resources/items/item_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::Item do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     item = Elmas::Item.new
     expect(item).to be_a(Elmas::Item)

--- a/spec/resources/mailboxes/mailboxes_api_spec.rb
+++ b/spec/resources/mailboxes/mailboxes_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::Mailbox do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     mailbox = Elmas::Mailbox.new
     expect(mailbox).to be_a(Elmas::Mailbox)

--- a/spec/resources/projects/projects_api_spec.rb
+++ b/spec/resources/projects/projects_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::Project do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     project = Elmas::Project.new
     expect(project).to be_a(Elmas::Project)

--- a/spec/resources/purchase_entries/purchase_entries_api_spec.rb
+++ b/spec/resources/purchase_entries/purchase_entries_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::PurchaseEntry do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     purchase_entry = Elmas::PurchaseEntry.new
     expect(purchase_entry).to be_a(Elmas::PurchaseEntry)

--- a/spec/resources/sales_entries/sales_entries_api_spec.rb
+++ b/spec/resources/sales_entries/sales_entries_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::SalesEntry do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     sales_entry = Elmas::SalesEntry.new
     expect(sales_entry).to be_a(Elmas::SalesEntry)

--- a/spec/resources/sales_entry_lines/sales_entry_lines_spec.rb
+++ b/spec/resources/sales_entry_lines/sales_entry_lines_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::SalesEntryLine do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     sales_entry_line = Elmas::SalesEntryLine.new
     expect(sales_entry_line).to be_a(Elmas::SalesEntryLine)

--- a/spec/resources/sales_order_lines/sales_order_lines_api_spec.rb
+++ b/spec/resources/sales_order_lines/sales_order_lines_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::SalesOrderLine do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     sales_order_line = Elmas::SalesOrderLine.new
     expect(sales_order_line).to be_a(Elmas::SalesOrderLine)

--- a/spec/resources/sales_orders/sales_orders_api_spec.rb
+++ b/spec/resources/sales_orders/sales_orders_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::SalesOrder do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     sales_order = Elmas::SalesOrder.new
     expect(sales_order).to be_a(Elmas::SalesOrder)

--- a/spec/resources/time_transactions/time_transactions_api_spec.rb
+++ b/spec/resources/time_transactions/time_transactions_api_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::TimeTransaction do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     project = Elmas::TimeTransaction.new
     expect(project).to be_a(Elmas::TimeTransaction)

--- a/spec/resources/transaction_lines/transaction_lines_spec.rb
+++ b/spec/resources/transaction_lines/transaction_lines_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 describe Elmas::TransactionLine do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
+
   it "can initialize" do
     transaction_line = Elmas::TransactionLine.new
     expect(transaction_line).to be_a(Elmas::TransactionLine)

--- a/spec/resources/transactions/transactions_spec.rb
+++ b/spec/resources/transactions/transactions_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::Transaction do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     transaction = Elmas::Transaction.new
     expect(transaction).to be_a(Elmas::Transaction)

--- a/spec/resources/vat_codes/vat_codes_spec.rb
+++ b/spec/resources/vat_codes/vat_codes_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Elmas::VatCode do
+
+  before do
+    stub_request(:get, "https://start.exactonline.nl/api/v1//Current/Me").
+       with(:headers => {'Accept'=>'application/response_format', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'Content-Type'=>'application/response_format', 'User-Agent'=>'Ruby'}).
+       to_return(:status => 200, :body => "", :headers => {})
+  end
+
   it "can initialize" do
     vat_code = Elmas::VatCode.new
     expect(vat_code).to be_a(Elmas::VatCode)


### PR DESCRIPTION
Hi

The access token issued by exact through oauth is only valid for 10 minutes.
After that you have to manually reauthorize. This change sends ai ping request
before the actual resource request, to determine if the access token is still
valid. If so, we just continue. If not, a reauthorization is performed and
then the resource request is send.

This implementation feels a bit blunt and I only made the spec tests work, but not test the actually reauthorization. I'm open for suggestions how these tests could look like. On my staging server, these change have been working nicely for the past 3 weeks.

regards,
Daniel