### PR TITLE
Support setting ledger id on invoice lines

### DIFF
--- a/lib/elmas/resources/sales_invoice_line.rb
+++ b/lib/elmas/resources/sales_invoice_line.rb
@@ -16,7 +16,7 @@ module Elmas
       SHARED_LINE_ATTRIBUTES.inject(
         [
           :employee, :end_time, :line_number, :start_time, :subscription,
-          :VAT_amount_DC, :VAT_amount_FC
+          :VAT_amount_DC, :VAT_amount_FC, :GL_account
         ],
         :<<
       )


### PR DESCRIPTION
Previously it was not possible to specify the ledger on invoice lines