### PR TITLE
make it easier to setup more diverse exact requests

### DIFF
--- a/lib/elmas/request.rb
+++ b/lib/elmas/request.rb
@@ -32,10 +32,11 @@ module Elmas
       path
     end
 
-    def add_headers
+    def add_headers(options = {})
+      content_type = options[:content_type] || "application/#{response_format}"
       headers = {}
-      headers["Content-Type"] = "application/#{response_format}"
-      headers["Accept"] = "application/#{response_format}"
+      headers["Content-Type"] = content_type
+      headers["Accept"] = content_type
       headers["Authorization"] = "Bearer #{access_token}" if access_token
       headers
     end
@@ -48,11 +49,11 @@ module Elmas
         case method
         when :post, :put
           request.url path
-          request.body = options[:params].to_json
+          request.body = options[:body] || options[:params].to_json
         when :get, :delete
           request.url path
         end
-        request.headers = add_headers
+        request.headers = add_headers(options)
       end
       Response.new(response)
     end


### PR DESCRIPTION
Hi,
These changes make the requests to exact slightly more flexible to configure.
This is useful to reuse the Request class also connecting to the XML-API of exact.
Some functionality of exact is not available through the Rest-API. I had to build one functionality for matching invoices via XML-API. In Order to reuse the same connector in the gem, I needed these changes and it would be nice to have them within the gem.

thanks for considering,
Daniel