### PR TITLE
Update gemspec to use resolve mime-types 3.x for > ruby 2.x

### DIFF
--- a/elmas.gemspec
+++ b/elmas.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.version       = Elmas::Version.to_s
 
   spec.add_dependency "faraday", [">= 0.8", "< 0.10"]
-  spec.add_dependency "mechanize", "2.6.0"
+  spec.add_dependency "mechanize", "2.7.5"
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler"

--- a/lib/elmas/oauth.rb
+++ b/lib/elmas/oauth.rb
@@ -10,7 +10,7 @@ module Elmas
   module OAuth
     def authorize(user_name, password, options = {})
       agent = Mechanize.new
-
+      agent.log = Logger.new('log/mechanize.log') 
       login(agent, user_name, password, options)
       allow_access(agent)
 


### PR DESCRIPTION
using Mechanize 2.7.5 resolved ruby 2.x mime-types 3.x dependency.
