### PR TITLE
Use activeresource's ThreadsafeAttributes for thread safe config values

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'activeresource', github: 'rails/activeresource'
+
 # Specify your gem's dependencies in elmas.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'activeresource', github: 'rails/activeresource'
-
 # Specify your gem's dependencies in elmas.gemspec
 gemspec

--- a/elmas.gemspec
+++ b/elmas.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", [">= 0.12.1"]
   spec.add_dependency "mechanize", ">= 2.7.5"
   spec.add_dependency "activesupport"
+  spec.add_dependency "activeresource", ">= 5.0.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/elmas.gemspec
+++ b/elmas.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", [">= 0.12.1"]
   spec.add_dependency "mechanize", ">= 2.7.5"
   spec.add_dependency "activesupport"
-  spec.add_dependency "activeresource", ">= 5.0.0"
+  spec.add_dependency "activeresource"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/lib/elmas/config.rb
+++ b/lib/elmas/config.rb
@@ -1,7 +1,9 @@
 require "faraday"
+require "active_resource/threadsafe_attributes"
 
 module Elmas
   module Config
+    include ThreadsafeAttributes
     # An array of valid keys in the options hash
     VALID_OPTIONS_KEYS = [
       :access_token,
@@ -58,7 +60,7 @@ module Elmas
     VALID_FORMATS = [:json].freeze
 
     # @private
-    attr_accessor *VALID_OPTIONS_KEYS
+    threadsafe_attribute(*VALID_OPTIONS_KEYS)
 
     # When this module is extended, set all configuration options to their default values
     def self.extended(base)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -14,4 +14,22 @@ describe Elmas do
 
     expect(Elmas.config[:base_url]).to eq(new_url)
   end
+
+  it "should be thread safe" do
+    Elmas.configure { |config| config.base_url = 'foo' }
+
+    Thread.new do
+      Elmas.configure { |config| config.base_url = 'bar' }
+    end.join
+
+    expect(Elmas.config[:base_url]).to eq 'foo'
+  end
+
+  it "should default to main thread values" do
+    Elmas.configure { |config| config.base_url = 'foo' }
+
+    Thread.new do
+      expect(Elmas.config[:base_url]).to eq 'foo'
+    end.join
+  end
 end


### PR DESCRIPTION
This PR proposes using Rails' activeresource's `ThreadsafeAttributes` to make this gem thread safe. 