### PR TITLE
Inherit from StandardError for custom exceptions

### DIFF
--- a/lib/elmas/exception.rb
+++ b/lib/elmas/exception.rb
@@ -1,5 +1,5 @@
 module Elmas
-  class BadRequestException < Exception
+  class BadRequestException < StandardError
     def initialize(response, parsed)
       @response = response
       @parsed = parsed
@@ -11,5 +11,5 @@ module Elmas
     end
   end
 
-  class UnauthorizedException < Exception; end
+  class UnauthorizedException < StandardError; end
 end


### PR DESCRIPTION
Trivial change without much consequence, but its a bit of a faux pas to inherit directly from the root of the exception hierarchy.