### PR TITLE
Add possibility to filter on Date or Time

### DIFF
--- a/lib/elmas/uri.rb
+++ b/lib/elmas/uri.rb
@@ -46,12 +46,17 @@ module Elmas
 
       # Convert a value to something usable in an ExactOnline request
       def sanitize_value(value)
-        if value.is_a?(String)
+        case value
+        when String
           if value =~ /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
             "guid'#{value}'"
           else
             "'#{value}'"
           end
+
+        when Date, Time
+          "datetime'#{value.strftime("%FT%TZ")}'"
+
         else
           value
         end

--- a/lib/elmas/uri.rb
+++ b/lib/elmas/uri.rb
@@ -55,7 +55,7 @@ module Elmas
           end
 
         when Date, Time
-          "datetime'#{value.strftime("%FT%TZ")}'"
+          "datetime'#{value.strftime('%FT%TZ')}'"
 
         else
           value

--- a/spec/resources/bank_entries/bank_entries_api_spec.rb
+++ b/spec/resources/bank_entries/bank_entries_api_spec.rb
@@ -33,7 +33,14 @@ describe Elmas::BankEntry do
     expect(sales_entry.valid?).to eq(false)
   end
 
-  let(:resource) { resource = Elmas::BankEntry.new(id: "12abcdef-1234-1234-1234-123456abcdef", financial_year: "1223") }
+  let(:resource) {
+    Elmas::BankEntry.new(
+      id: "12abcdef-1234-1234-1234-123456abcdef",
+      financial_year: "1223",
+      created: { ge: Date.new(2016, 6, 1) },
+      modified: { lt: DateTime.new(2016, 12, 31, 13, 37) }
+    )
+  }
 
   context "Applying filters" do
     it "should apply ID filter for find" do
@@ -49,6 +56,11 @@ describe Elmas::BankEntry do
     it "should apply given filters for find_by" do
       expect(Elmas).to receive(:get).with("financialtransaction/BankEntries?$filter=FinancialYear+eq+'1223'&$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
       resource.find_by(filters: [:financial_year, :id])
+    end
+
+    it "should apply date and time filters for find_by" do
+      expect(Elmas).to receive(:get).with("financialtransaction/BankEntries?$filter=Created+ge+datetime'2016-06-01T00:00:00Z'&$filter=Modified+lt+datetime'2016-12-31T13:37:00Z'")
+      resource.find_by(filters: [:created, :modified])
     end
   end
 


### PR DESCRIPTION
This pull request adds the possibility to use Date or Time values (or any classes having case equality, such as DateTime or ActiveSupport::TimeWithZone) in filters.

The select, order and filter tests are spread out over the many resources. I decided to only add the Date test to the spec fro BankEntry (the first spec which has Created and Modified fields).