### PR TITLE
Add security checks to class constantization

### DIFF
--- a/lib/elmas/result_set.rb
+++ b/lib/elmas/result_set.rb
@@ -44,8 +44,13 @@ module Elmas
 
     def resource_class
       @resource_class ||= begin
-        constant_name = Utils.modulize(type)
-        Object.const_get(constant_name, false)
+        constant_name = type.classify
+        raise NameError if constant_name !~ /\A[a-zA-Z0-9]+\z/
+
+        klass = Elmas.const_get(constant_name, false)
+        raise NameError if !klass.included_modules.include?(Elmas::Resource)
+
+        klass
       rescue NameError
         Elmas.info("Unknown resource encountered, proceed as usual but further resource details might have to be implemented")
         Class.new { include Elmas::Resource }

--- a/lib/elmas/result_set.rb
+++ b/lib/elmas/result_set.rb
@@ -45,7 +45,7 @@ module Elmas
     def resource_class
       @resource_class ||= begin
         constant_name = Utils.modulize(type)
-        Object.const_get(constant_name)
+        Object.const_get(constant_name, false)
       rescue NameError
         Elmas.info("Unknown resource encountered, proceed as usual but further resource details might have to be implemented")
         Class.new { include Elmas::Resource }

--- a/lib/elmas/result_set.rb
+++ b/lib/elmas/result_set.rb
@@ -45,10 +45,10 @@ module Elmas
     def resource_class
       @resource_class ||= begin
         constant_name = type.classify
-        raise NameError if constant_name !~ /\A[a-zA-Z0-9]+\z/
+        fail NameError unless constant_name =~ /\A[a-zA-Z0-9]+\z/
 
         klass = Elmas.const_get(constant_name, false)
-        raise NameError if !klass.included_modules.include?(Elmas::Resource)
+        fail NameError unless klass.included_modules.include?(Elmas::Resource)
 
         klass
       rescue NameError


### PR DESCRIPTION
Constantization of user-input data is a security risk, because without additional checks the user can pick any class it so desires and probably execute arbitrary code. In this instance the resource name Exact sends back is constantized without any checks. Of course Exact is a semi-trusted user, but doing this is still a bad idea. Note that prepending `Elmas::` (through `Utils.modulize`) will do nothing, because you can lookup top-level constants through any module (i.e. `Elmas::String == String`)

The solution in this PR is a bit of an exercise in defensive programming. The most important part is passing `false` as second argument to `const_get`. You can opt to only merge the first commit.

This method is still not as secure as it can be. Maintaining a whitelist of constantizable strings is a better way, and maintaining a mapping of strings to classes without any constantization would be best.