### PR TITLE
Fix OAuth flow for users that use different redirect_uri than postmaster.

### DIFF
--- a/lib/elmas/oauth.rb
+++ b/lib/elmas/oauth.rb
@@ -81,6 +81,7 @@ module Elmas
 
     def allow_access(agent)
       return if agent.page.uri.to_s.include?("getpostman")
+      return if agent.page.uri.to_s.include?(self.redirect_uri)
       form = agent.page.form_with(id: "PublicOAuth2Form")
       button = form.button_with(id: "AllowButton")
       agent.submit(form, button)


### PR DESCRIPTION
This fix will solve issues with the OAuth flow, after debugging we found that when using getpostman redirect URL everything went fine in all scenarios. But when using a different redirect_uri set in ENV broke the flow completely. This will solve some other issues maybe such as #58 and #18 that others have been experiencing. 