### PR TITLE
Add redirect_uri to auto_authorize method to simplify first time use

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,8 @@ So combining all of this results in
 Elmas.configure do |config|
   config.client_id = ENV['CLIENT_ID']
   config.client_secret = ENV['CLIENT_SECRET']
-end
-Elmas.configure do |config|
+  config.redirect_uri = ENV['REDIRECT_URI']
   config.access_token = Elmas.authorize(ENV['EXACT_USER_NAME'], ENV['EXACT_PASSWORD']).access_token
-end
-Elmas.configure do |config|
   config.division = Elmas.authorize_division
 end
 ```

--- a/lib/elmas/oauth.rb
+++ b/lib/elmas/oauth.rb
@@ -32,13 +32,10 @@ module Elmas
 
     def auto_authorize
       Elmas.configure do |config|
+        config.redirect_uri = ENV['REDIRECT_URI']
         config.client_id = ENV["CLIENT_ID"]
         config.client_secret = ENV["CLIENT_SECRET"]
-      end
-      Elmas.configure do |config|
         config.access_token = Elmas.authorize(ENV["EXACT_USER_NAME"], ENV["EXACT_PASSWORD"]).access_token
-      end
-      Elmas.configure do |config|
         config.division = Elmas.authorize_division
       end
     end


### PR DESCRIPTION
This can help newcomers in using the auto_authorize method so it will allow you to authorize any custom endpoint defined in Exact Online and ENV['REDIRECT_URI'].