### PR TITLE
Add division class usefull for retrieving all available divisions

### DIFF
--- a/lib/elmas.rb
+++ b/lib/elmas.rb
@@ -44,6 +44,7 @@ require "elmas/resources/vat_code"
 require "elmas/resources/general_journal_entry"
 require "elmas/resources/general_journal_entry_line"
 require "elmas/resources/payment_condition"
+require "elmas/resources/division"
 
 module Elmas
   extend Config

--- a/lib/elmas/resources/division.rb
+++ b/lib/elmas/resources/division.rb
@@ -1,0 +1,24 @@
+module Elmas
+  class Division
+    include Elmas::Resource
+
+    def base_path
+      "system/Divisions"
+    end
+
+    def mandatory_attributes
+      []
+    end
+
+    # https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SystemSystemDivisions
+    def other_attributes
+      [
+        :code, :address_line1, :address_line2, :address_line3,
+        :chamber_of_commerce_number, :city, :country, :created, :currency,
+        :current, :customer, :customer_code, :customer_name, :description,
+        :email, :hid, :is_main_division, :modified, :phone, :postcode, :state,
+        :status, :VAT_number
+      ]
+    end
+  end
+end

--- a/spec/resources/system/divisions_api_spec.rb
+++ b/spec/resources/system/divisions_api_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Elmas::Division do
+  it "can initialize" do
+    division = Elmas::Division.new
+    expect(division).to be_a(Elmas::Division)
+  end
+
+  it "is valid without attributes" do
+    division = Elmas::Division.new
+    expect(division.valid?).to eq(true)
+  end
+
+  it "is valid with attributes" do
+    division = Elmas::Division.new(description: "Example division")
+    expect(division.valid?).to eq(true)
+  end
+
+  context "Applying filters" do
+    resource = Elmas::Division.new(id: 123)
+    it "should apply ID filter for find" do
+      expect(Elmas).to receive(:get).with("system/Divisions(guid'123')?")
+      resource.find
+    end
+
+    it "should apply no filters for find_all" do
+      expect(Elmas).to receive(:get).with("system/Divisions?")
+      resource.find_all
+    end
+
+    it "should apply given filters for find_by" do
+      resource = Elmas::Division.new(id: "12abcdef-1234-1234-1234-123456abcdef")
+      expect(Elmas).to receive(:get).with("system/Divisions?$filter=ID+eq+guid'12abcdef-1234-1234-1234-123456abcdef'")
+      resource.find_by(filters: [:id])
+    end
+  end
+end


### PR DESCRIPTION
If you are a user that does the bookking for multiple companies and organizations in Exact Online you may want to be able to see all possible divisions and division numbers that you can connect to.