### PR TITLE
Readd journal attribute to sales invoice

### DIFF
--- a/lib/elmas/resources/sales_invoice.rb
+++ b/lib/elmas/resources/sales_invoice.rb
@@ -17,7 +17,7 @@ module Elmas
 
     def other_attributes
       SHARED_SALES_ATTRIBUTES.inject(
-        %i[sales_invoice_lines due_date salesperson starter_sales_invoice_status type],
+        %i[sales_invoice_lines due_date salesperson starter_sales_invoice_status type journal],
         :<<
       )
     end

--- a/spec/resources/invoices/invoices_api_spec.rb
+++ b/spec/resources/invoices/invoices_api_spec.rb
@@ -20,7 +20,7 @@ describe Elmas::SalesInvoice do
     journal = "another-awesome-journal"
     id = "232878"
     sales_invoice = Elmas::SalesInvoice.new(journal: journal, ordered_by: Elmas::Contact.new(first_name: "Karel", last_name: "Appel", id: id))
-    expect(sales_invoice.sanitize).to eq({"OrderedBy" => id })
+    expect(sales_invoice.sanitize).to eq({"OrderedBy" => id, "Journal" => "another-awesome-journal" })
   end
 
   context "Applying filters" do


### PR DESCRIPTION
In https://github.com/exactonline/exactonline-api-ruby-client/pull/63 the `journal` attribute was removed. Although not required, it should still be possible to set it.