### PR TITLE
Change of bank_name to bank_account_holder_name

### DIFF
--- a/lib/elmas/resources/bank_account.rb
+++ b/lib/elmas/resources/bank_account.rb
@@ -23,9 +23,9 @@ module Elmas
       %i[
         id account account_name bank
         bank_account bank_description
-        bank_name BIC_code description
-        division format IBAN type
-        type_description main
+        bank_account_holder_name BIC_code
+        description division format IBAN
+        type type_description main
       ]
     end
   end


### PR DESCRIPTION
As seen in the documentation: 
https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=CRMBankAccounts
The BankName is obsolete