### PR TITLE
Add date to BaseEntryLine, which is parent for GeneralJournalEntryLin…

### DIFF
--- a/lib/elmas/resources/base_entry_line.rb
+++ b/lib/elmas/resources/base_entry_line.rb
@@ -13,7 +13,7 @@ module Elmas
         serial_number asset cost_center cost_unit description notes
         project quantity serial_number subscription tracking_number
         VAT_amount_FC VAT_base_amount_DC VAT_base_amount_FC VAT_code
-        VAT_percentage account
+        VAT_percentage account date
       ]
     end
   end


### PR DESCRIPTION
BaseEntryLine is the parent class for GeneralJournalEntryLine, as this doesn't have other attributes I added it to the BaseEntryLine as other attribute. 

https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=GeneralJournalEntryGeneralJournalEntryLines