### PR TITLE
Use CGI instead of URI since it is removed in ruby 3.x

### DIFF
--- a/lib/elmas/resource.rb
+++ b/lib/elmas/resource.rb
@@ -47,7 +47,7 @@ module Elmas
 
     # Normally use the url method (which applies the filters) but sometimes you only want to use the base path or other paths
     def get(uri = self.uri)
-      @response = Elmas.get(URI.unescape(uri.to_s))
+      @response = Elmas.get(CGI.unescape(uri.to_s))
     end
 
     def valid?


### PR DESCRIPTION
URI.unescape is no longer available in ruby 3.x

From https://ruby-doc.org/stdlib-2.7.0/libdoc/uri/rdoc/URI/Escape.html:
```
This method is obsolete and should not be used. Instead, use CGI.escape, URI.encode_www_form or URI.encode_www_form_component depending on your specific use case.
```